### PR TITLE
redirect guests to login instead of showing error in chat box

### DIFF
--- a/ajax_chat.php
+++ b/ajax_chat.php
@@ -33,7 +33,7 @@ $mode = (!in_array($mode, $mode_types) ? '' : $mode);
 // Give guest a notice so they know they aren't allowed to use the shoutbox.
 if(($config['shout_allow_guest'] == 0) && !$user->data['session_logged_in'])
 {
-	message_die(GENERAL_ERROR, $lang['Shoutbox_no_auth']);
+	redirect(append_sid(CMS_PAGE_LOGIN . '?redirect=' . CMS_PAGE_AJAX_CHAT, true));
 }
 
 $chat_room = request_var('chat_room', '');


### PR DESCRIPTION
If guest cannot access ajax chat, IP shows error message. This small change redirects guest to login instead of showing error.
