### PR TITLE
XS: clear cache when {un,}installing themes

### DIFF
--- a/adm/xs_install.php
+++ b/adm/xs_install.php
@@ -48,6 +48,7 @@ if(!empty($style) && !defined('DEMO_MODE'))
 	if($res)
 	{
 		$db->clear_cache('styles_');
+		$cache->destroy_datafiles(array('_styles'), MAIN_CACHE_FOLDER, 'data', false);
 		xs_message($lang['Information'], $lang['xs_install_installed'] . '<br /><br />' . $lang['xs_install_back'] . '<br /><br />' . $lang['xs_goto_default']);
 	}
 	xs_error($lang['xs_install_error'] . '<br /><br />' . $lang['xs_install_back']);
@@ -81,6 +82,7 @@ if(!empty($total) && !defined('DEMO_MODE'))
 			);
 		}
 		$db->clear_cache('styles_');
+		$cache->destroy_datafiles(array('_styles'), MAIN_CACHE_FOLDER, 'data', false);
 		xs_message($lang['Information'], $lang['xs_install_installed'] . '<br /><br />' . $lang['xs_install_back'] . '<br /><br />' . $lang['xs_goto_default']);
 	}
 }

--- a/adm/xs_uninstall.php
+++ b/adm/xs_uninstall.php
@@ -84,6 +84,11 @@ if(!empty($remove_id) && !defined('DEMO_MODE'))
 	$sql = "DELETE FROM " . THEMES_TABLE . " WHERE themes_id = '{$remove_id}'";
 	$db->sql_query($sql);
 	$template->assign_block_vars('removed', array());
+
+	// clear cache
+	$db->clear_cache('styles_');
+	$cache->destroy_datafiles(array('_styles'), MAIN_CACHE_FOLDER, 'data', false);
+
 	// remove files
 	if(!empty($remove_dir))
 	{


### PR DESCRIPTION
This fixes a bug: if you install or uninstall a theme, the theme list in the profile will not change.